### PR TITLE
test: add mutation and coverage report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,58 @@
                     <autoPublish>true</autoPublish>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>1.17.0</version>
+                <configuration>
+                    <targetClasses>
+                        <param>io.github.matheusmfranco.play.*</param>
+                    </targetClasses>
+                    <targetTests>
+                        <param>io.github.matheusmfranco.play.*Test</param>
+                    </targetTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>CLASS</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -144,8 +196,13 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.12</version>
+            <version>1.5.11</version>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-junit5-plugin</artifactId>
+            <version>1.2.1</version>
         </dependency>
     </dependencies>
 
@@ -180,5 +237,4 @@
             <name>Matheus Franco</name>
         </developer>
     </developers>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,15 @@
                         <param>io.github.matheusmfranco.play.*Test</param>
                     </targetTests>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>mutation-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>mutationCoverage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>


### PR DESCRIPTION
This commit introduces mutation testing with PIT and adds unit test coverage reporting using JaCoCo.
It was configured JaCoCo to generate unit test coverage reports in HTML.

To run **Mutation Tests Only**:
```
mvn org.pitest:pitest-maven:mutationCoverage
```
To see the **mutation tests report generated**:
```
target/pit-reports/index.html
```
To see the **unit tests report generated**:
```
target/site/jacoco/index.html
```
To run all of them:
```
mvn clean test
```

